### PR TITLE
Implement song progress bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1078,6 +1078,11 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
     "@fortawesome/fontawesome-free": {
       "version": "5.13.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz",
@@ -1306,6 +1311,85 @@
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
+      }
+    },
+    "@material-ui/core": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.13.tgz",
+      "integrity": "sha512-GEXNwUr+laZ0N+F1efmHB64Fyg+uQIRXLqbSejg3ebSXgLYNpIjnMOPRfWdu4rICq0dAIgvvNXGkKDMcf3AMpA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/react-transition-group": "^4.3.0",
+        "@material-ui/styles": "^4.9.13",
+        "@material-ui/system": "^4.9.13",
+        "@material-ui/types": "^5.0.1",
+        "@material-ui/utils": "^4.9.12",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "^1.16.1-lts",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0",
+        "react-transition-group": "^4.3.0"
+      }
+    },
+    "@material-ui/react-transition-group": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/react-transition-group/-/react-transition-group-4.3.0.tgz",
+      "integrity": "sha512-CwQ0aXrlUynUTY6sh3UvKuvye1o92en20VGAs6TORnSxUYeRmkX8YeTUN3lAkGiBX1z222FxLFO36WWh6q73rQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.9.13.tgz",
+      "integrity": "sha512-lWlXJanBdHQ18jW/yphedRokHcvZD1GdGzUF/wQxKDsHwDDfO45ZkAxuSBI202dG+r1Ph483Z3pFykO2obeSRA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.8.0",
+        "@material-ui/types": "^5.0.1",
+        "@material-ui/utils": "^4.9.6",
+        "clsx": "^1.0.4",
+        "csstype": "^2.5.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.0.3",
+        "jss-plugin-camel-case": "^10.0.3",
+        "jss-plugin-default-unit": "^10.0.3",
+        "jss-plugin-global": "^10.0.3",
+        "jss-plugin-nested": "^10.0.3",
+        "jss-plugin-props-sort": "^10.0.3",
+        "jss-plugin-rule-value-function": "^10.0.3",
+        "jss-plugin-vendor-prefixer": "^10.0.3",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.13.tgz",
+      "integrity": "sha512-6AlpvdW6KJJ5bF1Xo2OD13sCN8k+nlL36412/bWnWZOKIfIMo/Lb8c8d1DOIaT/RKWxTEUaWnKZjabVnA3eZjA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.9.6",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.0.1.tgz",
+      "integrity": "sha512-wURPSY7/3+MAtng3i26g+WKwwNE3HEeqa/trDBR5+zWKmcjO+u9t7Npu/J1r+3dmIa/OeziN9D/18IrBKvKffw=="
+    },
+    "@material-ui/utils": {
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.9.12.tgz",
+      "integrity": "sha512-/0rgZPEOcZq5CFA4+4n6Q6zk7fi8skHhH2Bcra8R3epoJEYy5PL55LuMazPtPH1oKeRausDV/Omz4BbgFsn1HQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1693,6 +1777,14 @@
       "version": "16.9.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.5.tgz",
       "integrity": "sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.2.4.tgz",
+      "integrity": "sha512-8DMUaDqh0S70TjkqU0DxOu80tFUiiaS9rxkWip/nb7gtvAsbqOXm02UCmR8zdcjWujgeYPiPNTVpVpKzUDotwA==",
       "requires": {
         "@types/react": "*"
       }
@@ -3430,6 +3522,11 @@
         "shallow-clone": "^0.1.2"
       }
     },
+    "clsx": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.0.tgz",
+      "integrity": "sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3922,6 +4019,15 @@
         }
       }
     },
+    "css-vendor": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "is-in-browser": "^1.0.2"
+      }
+    },
     "css-what": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
@@ -4377,6 +4483,30 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
+      "integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^2.6.7"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "dom-serializer": {
@@ -6303,6 +6433,11 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "hyphenate-style-name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6670,6 +6805,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-number": {
       "version": "3.0.0",
@@ -8008,6 +8148,83 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jss": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.1.1.tgz",
+      "integrity": "sha512-Xz3qgRUFlxbWk1czCZibUJqhVPObrZHxY3FPsjCXhDld4NOj1BgM14Ir5hVm+Qr6OLqVljjGvoMcCdXNOAbdkQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^2.6.5",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.1.1.tgz",
+      "integrity": "sha512-MDIaw8FeD5uFz1seQBKz4pnvDLnj5vIKV5hXSVdMaAVq13xR6SVTVWkIV/keyTs5txxTvzGJ9hXoxgd1WTUlBw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.1.1"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.1.1.tgz",
+      "integrity": "sha512-UkeVCA/b3QEA4k0nIKS4uWXDCNmV73WLHdh2oDGZZc3GsQtlOCuiH3EkB/qI60v2MiCq356/SYWsDXt21yjwdg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.1.1"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.1.1.tgz",
+      "integrity": "sha512-VBG3wRyi3Z8S4kMhm8rZV6caYBegsk+QnQZSVmrWw6GVOT/Z4FA7eyMu5SdkorDlG/HVpHh91oFN56O4R9m2VA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.1.1"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.1.1.tgz",
+      "integrity": "sha512-ozEu7ZBSVrMYxSDplPX3H82XHNQk2DQEJ9TEyo7OVTPJ1hEieqjDFiOQOxXEj9z3PMqkylnUbvWIZRDKCFYw5Q==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.1.1",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.1.1.tgz",
+      "integrity": "sha512-g/joK3eTDZB4pkqpZB38257yD4LXB0X15jxtZAGbUzcKAVUHPl9Jb47Y7lYmiGsShiV4YmQRqG1p2DHMYoK91g==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.1.1"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.1.1.tgz",
+      "integrity": "sha512-ClV1lvJ3laU9la1CUzaDugEcwnpjPTuJ0yGy2YtcU+gG/w9HMInD5vEv7xKAz53Bk4WiJm5uLOElSEshHyhKNw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.1.1"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.1.1.tgz",
+      "integrity": "sha512-09MZpQ6onQrhaVSF6GHC4iYifQ7+4YC/tAP6D4ZWeZotvCMq1mHLqNKRIaqQ2lkgANjlEot2JnVi1ktu4+L4pw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.7",
+        "jss": "10.1.1"
       }
     },
     "jsx-ast-utils": {
@@ -9498,6 +9715,11 @@
       "requires": {
         "ts-pnp": "^1.1.6"
       }
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "portfinder": {
       "version": "1.0.25",
@@ -11124,6 +11346,17 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
       "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
+    },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
     },
     "read-pkg": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
+    "@material-ui/core": "^4.9.13",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
@@ -17,7 +18,7 @@
     "react-dom": "^16.13.1",
     "react-helmet": "^6.0.0",
     "react-load-script": "0.0.6",
-    "react-player": "^2.0.0",
+    "react-player": "^2.0.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
     "youtube-player": "^5.5.2"

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,6 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#ffffff" />
-    <meta name="description" content="Music streaming aggregator" />
     <link
       rel="apple-touch-icon"
       sizes="120x120"

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -67,9 +67,7 @@ class Player extends Component {
       onPlayClick,
       onEnded,
       onDuration,
-      onSeek,
       onProgress,
-      onReady,
       onPlayerRef,
     } = this.props;
     const { hostId, host, name, artist } = selectedSong;
@@ -106,9 +104,7 @@ class Player extends Component {
               onPause={onPause}
               onEnded={onEnded}
               onDuration={onDuration}
-              onSeek={onSeek}
               onProgress={(state) => onProgress(state.playedSeconds)}
-              onReady={onReady}
             />
           )}
           {host === "Spotify" && (
@@ -119,6 +115,7 @@ class Player extends Component {
               onPlayClick={onPlayClick}
               onEnded={onEnded}
               onProgress={onProgress}
+              onDuration={onDuration}
             />
           )}
         </div>
@@ -134,6 +131,9 @@ Player.propTypes = {
   onPause: PropTypes.func.isRequired,
   onPlayClick: PropTypes.func.isRequired,
   onEnded: PropTypes.func.isRequired,
+  onDuration: PropTypes.func.isRequired,
+  onProgress: PropTypes.func.isRequired,
+  onPlayerRef: PropTypes.func.isRequired,
 };
 
 export default Player;

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -9,7 +9,7 @@ import { Helmet } from "react-helmet";
 // TODO: move these constants in a config file + comment values
 const youtubeUrlPrefix = "https://www.youtube.com/watch?v=";
 const youtubeConfig = {
-  controls: 1,
+  controls: 0,
   disablekb: 1,
   fs: 0,
   cc_load_policy: 0,
@@ -66,6 +66,11 @@ class Player extends Component {
       onPause,
       onPlayClick,
       onEnded,
+      onDuration,
+      onSeek,
+      onProgress,
+      onReady,
+      onPlayerRef,
     } = this.props;
     const { hostId, host, name, artist } = selectedSong;
     const url = this.getUrl(hostId, host);
@@ -82,11 +87,13 @@ class Player extends Component {
         <div className="player-wrapper">
           {host !== "Spotify" && (
             <ReactPlayer
+              ref={onPlayerRef}
               className="react-player"
               url={url}
               width="100%"
               controls={false}
               playing={isPlaying}
+              progressInterval={20}
               config={{
                 youtube: {
                   playerVars: youtubeConfig,
@@ -98,6 +105,10 @@ class Player extends Component {
               onPlay={onPlay}
               onPause={onPause}
               onEnded={onEnded}
+              onDuration={onDuration}
+              onSeek={onSeek}
+              onProgress={(state) => onProgress(state.playedSeconds)}
+              onReady={onReady}
             />
           )}
           {host === "Spotify" && (

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -37,6 +37,14 @@ class Player extends Component {
     getSpotifyTokenFromHash();
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.reactPlayerInstance) {
+      if (prevProps.seekTo !== this.props.seekTo) {
+        this.reactPlayerInstance.seekTo(this.props.seekTo, "seconds");
+      }
+    }
+  }
+
   handleScriptCreate = () => {
     window.onSpotifyWebPlaybackSDKReady = () => {
       console.log(
@@ -58,6 +66,11 @@ class Player extends Component {
     }
   };
 
+  getReactPlayerInstance = (reactPlayerInstance) => {
+    // Required for seeking to a specific position
+    this.reactPlayerInstance = reactPlayerInstance;
+  };
+
   render() {
     const {
       selectedSong,
@@ -68,7 +81,7 @@ class Player extends Component {
       onEnded,
       onDuration,
       onProgress,
-      onPlayerRef,
+      seekTo,
     } = this.props;
     const { hostId, host, name, artist } = selectedSong;
     const url = this.getUrl(hostId, host);
@@ -85,7 +98,7 @@ class Player extends Component {
         <div className="player-wrapper">
           {host !== "Spotify" && (
             <ReactPlayer
-              ref={onPlayerRef}
+              ref={this.getReactPlayerInstance}
               className="react-player"
               url={url}
               width="100%"
@@ -116,6 +129,7 @@ class Player extends Component {
               onEnded={onEnded}
               onProgress={onProgress}
               onDuration={onDuration}
+              seekTo={seekTo}
             />
           )}
         </div>
@@ -133,7 +147,6 @@ Player.propTypes = {
   onEnded: PropTypes.func.isRequired,
   onDuration: PropTypes.func.isRequired,
   onProgress: PropTypes.func.isRequired,
-  onPlayerRef: PropTypes.func.isRequired,
 };
 
 export default Player;

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -118,6 +118,7 @@ class Player extends Component {
               isPlaying={isPlaying}
               onPlayClick={onPlayClick}
               onEnded={onEnded}
+              onProgress={onProgress}
             />
           )}
         </div>

--- a/src/components/PlayerControls.jsx
+++ b/src/components/PlayerControls.jsx
@@ -5,28 +5,26 @@ function PlayerControls(props) {
   const { isPlaying, onPlayClick, onPreviousClick, onNextClick } = props;
 
   return (
-    <footer className="py-4 bg-light">
-      <div className="container text-center">
-        <button
-          className="btn btn-primary btn-circle-l m-1"
-          onClick={() => onPreviousClick()}
-        >
-          <i className={"fas fa-backward"} />
-        </button>
-        <button
-          className="btn btn-primary btn-circle btn-circle-xl m-1"
-          onClick={() => onPlayClick()}
-        >
-          <i className={isPlaying ? "fas fa-pause" : "fas fa-play"} />
-        </button>
-        <button
-          className="btn btn-primary btn-circle-l m-1"
-          onClick={() => onNextClick()}
-        >
-          <i className={"fas fa-forward"} />
-        </button>
-      </div>
-    </footer>
+    <div className="container text-center">
+      <button
+        className="btn btn-primary btn-circle-l m-1"
+        onClick={() => onPreviousClick()}
+      >
+        <i className={"fas fa-backward"} />
+      </button>
+      <button
+        className="btn btn-primary btn-circle btn-circle-xl m-1"
+        onClick={() => onPlayClick()}
+      >
+        <i className={isPlaying ? "fas fa-pause" : "fas fa-play"} />
+      </button>
+      <button
+        className="btn btn-primary btn-circle-l m-1"
+        onClick={() => onNextClick()}
+      >
+        <i className={"fas fa-forward"} />
+      </button>
+    </div>
   );
 }
 

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -1,7 +1,7 @@
 import { Slider } from "@material-ui/core";
 import { withStyles } from "@material-ui/core/styles";
 
-const ProgressSlider = withStyles({
+const ProgressBar = withStyles({
   root: {
     color: "#007bff",
     height: 8,
@@ -33,4 +33,4 @@ const ProgressSlider = withStyles({
   },
 })(Slider);
 
-export default ProgressSlider;
+export default ProgressBar;

--- a/src/components/ProgressSlider.jsx
+++ b/src/components/ProgressSlider.jsx
@@ -1,0 +1,36 @@
+import { Slider } from "@material-ui/core";
+import { withStyles } from "@material-ui/core/styles";
+
+const ProgressSlider = withStyles({
+  root: {
+    color: "#007bff",
+    height: 8,
+    paddingTop: "0px",
+    marginBottom: "5px",
+  },
+  thumb: {
+    height: 24,
+    width: 24,
+    backgroundColor: "#fff",
+    border: "2px solid currentColor",
+    marginTop: -8,
+    marginLeft: -12,
+    "&:focus, &:hover, &$active": {
+      boxShadow: "inherit",
+    },
+  },
+  active: {},
+  valueLabel: {
+    left: "calc(-50% + 4px)",
+  },
+  track: {
+    height: 8,
+    borderRadius: 4,
+  },
+  rail: {
+    height: 8,
+    borderRadius: 4,
+  },
+})(Slider);
+
+export default ProgressSlider;

--- a/src/components/ShowPlaylist.jsx
+++ b/src/components/ShowPlaylist.jsx
@@ -222,7 +222,7 @@ class ShowPlaylist extends Component {
         </main>
         <footer className="bg-light" style={{ "padding-bottom": "20px" }}>
           <Slider
-            style={{ "padding-top": "0px" }}
+            style={{ "padding-top": "0px", "margin-bottom": "5px" }}
             defaultValue={0}
             min={0}
             max={duration}

--- a/src/components/ShowPlaylist.jsx
+++ b/src/components/ShowPlaylist.jsx
@@ -83,6 +83,13 @@ class ShowPlaylist extends Component {
     return sortedSongs;
   };
 
+  formatSliderLaber = (progressValue) => {
+    const millis = progressValue * 1000;
+    const minutes = Math.floor(millis / 60000);
+    const seconds = ((millis % 60000) / 1000).toFixed(0);
+    return minutes + ":" + (seconds < 10 ? "0" : "") + seconds;
+  };
+
   handleDeleteButton = async (id) => {
     const { songs } = this.state;
     const originalSongs = songs;
@@ -210,12 +217,14 @@ class ShowPlaylist extends Component {
           </div>
         </main>
         <Slider
+          defaultValue={0}
           min={0}
           max={duration}
           value={progressValue}
           onChange={this.handleSliderChange}
           aria-labelledby="continuous-slider"
-          // getAriaValueText={this.state.value.toString()}
+          valueLabelDisplay="auto"
+          valueLabelFormat={(value) => this.formatSliderLaber(value)}
         />
         <PlayerControls
           isPlaying={isPlaying}

--- a/src/components/ShowPlaylist.jsx
+++ b/src/components/ShowPlaylist.jsx
@@ -156,8 +156,8 @@ class ShowPlaylist extends Component {
     this.setState({ duration });
   };
 
-  handleProgress = (playedSeconds) => {
-    this.setState({ progressValue: playedSeconds });
+  handleProgress = (progressValue) => {
+    this.setState({ progressValue });
   };
 
   handleSliderChange = (event, progressValue) => {

--- a/src/components/ShowPlaylist.jsx
+++ b/src/components/ShowPlaylist.jsx
@@ -5,8 +5,7 @@ import { getSongs } from "../services/fakePlaylistService";
 import _ from "lodash";
 import Player from "./Player";
 import PlayerControls from "./PlayerControls";
-import { Slider } from "@material-ui/core";
-import { withStyles, makeStyles } from "@material-ui/core/styles";
+import ProgressSlider from "./ProgressSlider";
 
 class ShowPlaylist extends Component {
   state = {
@@ -221,8 +220,7 @@ class ShowPlaylist extends Component {
           </div>
         </main>
         <footer className="bg-light" style={{ "padding-bottom": "20px" }}>
-          <Slider
-            style={{ "padding-top": "0px", "margin-bottom": "5px" }}
+          <ProgressSlider
             defaultValue={0}
             min={0}
             max={duration}

--- a/src/components/ShowPlaylist.jsx
+++ b/src/components/ShowPlaylist.jsx
@@ -6,6 +6,7 @@ import _ from "lodash";
 import Player from "./Player";
 import PlayerControls from "./PlayerControls";
 import { Slider } from "@material-ui/core";
+import { withStyles, makeStyles } from "@material-ui/core/styles";
 
 class ShowPlaylist extends Component {
   state = {
@@ -219,22 +220,25 @@ class ShowPlaylist extends Component {
             </div>
           </div>
         </main>
-        <Slider
-          defaultValue={0}
-          min={0}
-          max={duration}
-          value={progressValue}
-          onChange={this.handleSliderChange}
-          aria-labelledby="continuous-slider"
-          valueLabelDisplay="auto"
-          valueLabelFormat={(value) => this.formatSliderLaber(value)}
-        />
-        <PlayerControls
-          isPlaying={isPlaying}
-          onPlayClick={this.handlePlayButtonClick}
-          onPreviousClick={this.handlePreviousButtonClick}
-          onNextClick={this.handleNextButtonClick}
-        />
+        <footer className="bg-light" style={{ "padding-bottom": "20px" }}>
+          <Slider
+            style={{ "padding-top": "0px" }}
+            defaultValue={0}
+            min={0}
+            max={duration}
+            value={progressValue}
+            onChange={this.handleSliderChange}
+            aria-labelledby="continuous-slider"
+            valueLabelDisplay="auto"
+            valueLabelFormat={(value) => this.formatSliderLaber(value)}
+          />
+          <PlayerControls
+            isPlaying={isPlaying}
+            onPlayClick={this.handlePlayButtonClick}
+            onPreviousClick={this.handlePreviousButtonClick}
+            onNextClick={this.handleNextButtonClick}
+          />
+        </footer>
       </React.Fragment>
     );
   }

--- a/src/components/ShowPlaylist.jsx
+++ b/src/components/ShowPlaylist.jsx
@@ -17,6 +17,7 @@ class ShowPlaylist extends Component {
     isPlaying: false,
     progressValue: 0,
     duration: 0,
+    seekTo: 0,
   };
 
   componentDidMount() {
@@ -156,24 +157,25 @@ class ShowPlaylist extends Component {
     this.setState({ duration });
   };
 
+  // Needed for sync possible slide bar changes in Player (i.e. SoundCloud). Could be removed.
   handleProgress = (progressValue) => {
     this.setState({ progressValue });
   };
 
   handleSliderChange = (event, progressValue) => {
-    this.setState({ progressValue });
-    if (this.reactPlayerInstance) {
-      this.reactPlayerInstance.seekTo(progressValue, "seconds");
-    }
-  };
-
-  getReactPlayerInstance = (reactPlayerInstance) => {
-    // TODO: Ugly stuff.. required for seeking to a specific position. Refactor into Player
-    this.reactPlayerInstance = reactPlayerInstance;
+    this.setState({ progressValue, seekTo: progressValue });
   };
 
   render() {
-    const { searchQuery, sortColumn, selectedSong, isPlaying } = this.state;
+    const {
+      searchQuery,
+      sortColumn,
+      selectedSong,
+      isPlaying,
+      duration,
+      progressValue,
+      seekTo,
+    } = this.state;
     const data = this.getSortedSongs();
 
     return (
@@ -184,13 +186,13 @@ class ShowPlaylist extends Component {
               <Player
                 selectedSong={selectedSong}
                 isPlaying={isPlaying}
+                seekTo={seekTo}
                 onPlay={this.handlePlayerOnPlay}
                 onPause={this.handlePlayerOnPause}
                 onPlayClick={this.handlePlayButtonClick}
                 onEnded={this.handleSongEnded}
                 onProgress={this.handleProgress}
                 onDuration={this.handleDuration}
-                onPlayerRef={this.getReactPlayerInstance}
               />
             </div>
 
@@ -209,8 +211,8 @@ class ShowPlaylist extends Component {
         </main>
         <Slider
           min={0}
-          max={this.state.duration}
-          value={this.state.progressValue}
+          max={duration}
+          value={progressValue}
           onChange={this.handleSliderChange}
           aria-labelledby="continuous-slider"
           // getAriaValueText={this.state.value.toString()}

--- a/src/components/ShowPlaylist.jsx
+++ b/src/components/ShowPlaylist.jsx
@@ -170,6 +170,9 @@ class ShowPlaylist extends Component {
   };
 
   handleSliderChange = (event, progressValue) => {
+    if (!this.state.isPlaying) {
+      this.handlePlayButtonClick();
+    }
     this.setState({ progressValue, seekTo: progressValue });
   };
 

--- a/src/components/ShowPlaylist.jsx
+++ b/src/components/ShowPlaylist.jsx
@@ -5,7 +5,7 @@ import { getSongs } from "../services/fakePlaylistService";
 import _ from "lodash";
 import Player from "./Player";
 import PlayerControls from "./PlayerControls";
-import ProgressSlider from "./ProgressSlider";
+import ProgressBar from "./ProgressBar";
 
 class ShowPlaylist extends Component {
   state = {
@@ -220,7 +220,7 @@ class ShowPlaylist extends Component {
           </div>
         </main>
         <footer className="bg-light" style={{ "padding-bottom": "20px" }}>
-          <ProgressSlider
+          <ProgressBar
             defaultValue={0}
             min={0}
             max={duration}

--- a/src/components/spotify/SpotifyPlayer.jsx
+++ b/src/components/spotify/SpotifyPlayer.jsx
@@ -16,6 +16,7 @@ const SpotifyPlayer = ({
   onPlayClick,
   onEnded,
   onProgress,
+  onDuration,
 }) => {
   const token = getToken();
   return (
@@ -34,6 +35,7 @@ const SpotifyPlayer = ({
           onPlayClick={onPlayClick}
           onEnded={onEnded}
           onProgress={onProgress}
+          onDuration={onDuration}
         />
       )}
     </React.Fragment>
@@ -46,6 +48,8 @@ SpotifyPlayer.propTypes = {
   isPlaying: PropTypes.bool.isRequired,
   onPlayClick: PropTypes.func.isRequired,
   onEnded: PropTypes.func.isRequired,
+  onProgress: PropTypes.func.isRequired,
+  onDuration: PropTypes.func.isRequired,
 };
 
 export default SpotifyPlayer;

--- a/src/components/spotify/SpotifyPlayer.jsx
+++ b/src/components/spotify/SpotifyPlayer.jsx
@@ -17,6 +17,7 @@ const SpotifyPlayer = ({
   onEnded,
   onProgress,
   onDuration,
+  seekTo,
 }) => {
   const token = getToken();
   return (
@@ -30,6 +31,7 @@ const SpotifyPlayer = ({
         <SpotitySong
           token={token}
           url={url}
+          seekTo={seekTo}
           songId={selectedSong.hostId}
           isPlaying={isPlaying}
           onPlayClick={onPlayClick}

--- a/src/components/spotify/SpotifyPlayer.jsx
+++ b/src/components/spotify/SpotifyPlayer.jsx
@@ -15,6 +15,7 @@ const SpotifyPlayer = ({
   isPlaying,
   onPlayClick,
   onEnded,
+  onProgress,
 }) => {
   const token = getToken();
   return (
@@ -32,6 +33,7 @@ const SpotifyPlayer = ({
           isPlaying={isPlaying}
           onPlayClick={onPlayClick}
           onEnded={onEnded}
+          onProgress={onProgress}
         />
       )}
     </React.Fragment>

--- a/src/components/spotify/SpotifySong.jsx
+++ b/src/components/spotify/SpotifySong.jsx
@@ -15,9 +15,9 @@ class SpotitySong extends Component {
       artists: [{ name: "" }],
       album: { images: [{ url: "" }, { url: "" }, { url: "" }] },
     },
-    progressValue: 0,
+    progressValue: 0, // TODO: maybe remove
   };
-  _isMounted = false; // Used to prevent setStates in Spotify callbacks
+  _isMounted = false; // Used to prevent setStates in Spotify callbacks during shutdown
 
   async componentDidMount() {
     this._isMounted = true;
@@ -119,7 +119,7 @@ class SpotitySong extends Component {
 
       if (printDebug) {
         console.log("player_state_changed", state);
-        console.log("current track", state.track_window.current_track);
+        // console.log("current track", state.track_window.current_track);
       }
       this.setState({ currentTrack: state.track_window.current_track });
       state.updateTime = performance.now();
@@ -131,7 +131,7 @@ class SpotitySong extends Component {
       // TODO: disable play/pause button until everything is loaded
       console.log("Ready with Device ID", device_id);
       this.setState({ isReady: true });
-      this.interval = setInterval(this.getProgressValue, 500);
+      this.interval = setInterval(this.getProgressValue, 500); // TODO: use 20ms
       if (this.props.isPlaying) {
         this.play(this.props.url);
       }
@@ -169,6 +169,7 @@ class SpotitySong extends Component {
 
   getProgressValue = () => {
     const { playerState } = this.state;
+
     if (!playerState) {
       console.log("progressValue: 0");
       this.setState({ progressValue: 0 });
@@ -187,13 +188,24 @@ class SpotitySong extends Component {
     }
 
     const position =
-      playerState.position +
-      (performance.now() - playerState.updateTime) / 1000;
-    const return_value =
+      (playerState.position + (performance.now() - playerState.updateTime)) /
+      1000;
+
+    const progressValue =
       position > playerState.duration ? playerState.duration / 1000 : position;
-    console.log("progressValue:", return_value);
-    this.setState({ progressValue: return_value });
-    this.props.onProgress(return_value);
+
+    console.log(
+      "progressValue: " +
+        progressValue +
+        " position: " +
+        position +
+        " playerState.position: " +
+        playerState.position +
+        " playerState.duration: " +
+        playerState.duration
+    );
+    this.setState({ progressValue });
+    this.props.onProgress(progressValue);
   };
 
   getAlbumCoverUrl = (currentTrack) => {
@@ -210,7 +222,7 @@ class SpotitySong extends Component {
   };
 
   render() {
-    const { currentTrack, playerState } = this.state;
+    const { currentTrack, playerState, progressValue } = this.state;
     const { isPlaying, onPlayClick } = this.props;
 
     const albumCoverUrl = this.getAlbumCoverUrl(currentTrack);
@@ -237,6 +249,9 @@ class SpotitySong extends Component {
               </h2>
               <h2>
                 <b>Is playing?</b> {isPlaying ? "Yes" : "No"}
+              </h2>
+              <h2>
+                <b>Progress Value</b> {progressValue}
               </h2>
               <button
                 className="btn btn-warning"

--- a/src/services/fakePlaylistService.js
+++ b/src/services/fakePlaylistService.js
@@ -25,6 +25,14 @@ export const songs = [
     hostId: "r-srecords/aphex-twin-polynomial-c-1",
   },
   {
+    _id: "5b21ca3eeb7f6fbccd4718",
+    artist: "Aphex Twin",
+    name: "Didgeridoo",
+    duration: "110",
+    host: "SoundCloud",
+    hostId: "r-srecords/aphex-twin-digeridoo-2",
+  },
+  {
     _id: "5b21ca3eeb7f6fbccd471",
     artist: "Cassius",
     name: "Cassius 1999",


### PR DESCRIPTION
Implementation of a first version of progress bar.

It will:
- show current track position
- show current track duration
- let user seek to any position via mouse

Known issues:
- if SoundCloud songs change to another SoundCloud, position takes some time to update
- if YouTube songs change to another YouTube, duration is not updated until played https://github.com/CookPete/react-player/issues/880
- Spotify song must be played before doing seek to (API doesn't permit to load song beforehand)